### PR TITLE
add a softdelete flag to bq resources

### DIFF
--- a/provider_test.go
+++ b/provider_test.go
@@ -15,7 +15,7 @@ var testAccProvider *schema.Provider
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
-		"google": testAccProvider,
+		"googlebigquery": testAccProvider,
 	}
 }
 

--- a/resource_bigquery_dataset.go
+++ b/resource_bigquery_dataset.go
@@ -40,6 +40,12 @@ func resourceBigQueryDataset() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			
+			"softDelete": &schema.Schema{
+				Type:	  schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 
 			"access": &schema.Schema{
 				Type:     schema.TypeList,
@@ -221,10 +227,12 @@ func resourceBigQueryDatasetUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceBigQueryDatasetDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	call := config.clientBigQuery.Datasets.Delete(config.Project, d.Get("datasetId").(string))
-	err := call.Do()
-	if err != nil {
-		return err
+    if( false == d.Get("softDelete").(bool) ) {
+		call := config.clientBigQuery.Datasets.Delete(config.Project, d.Get("datasetId").(string))
+		err := call.Do()
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId("")

--- a/resource_bigquery_table.go
+++ b/resource_bigquery_table.go
@@ -47,6 +47,12 @@ func resourceBigQueryTable() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			
+			"softDelete": &schema.Schema{
+				Type:	  schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 
 			"schema": &schema.Schema{
 				Type:     schema.TypeList,
@@ -235,10 +241,12 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	call := config.clientBigQuery.Tables.Delete(config.Project, d.Get("datasetId").(string), d.Get("tableId").(string))
-	err := call.Do()
-	if err != nil {
-		return err
+    if( false == d.Get("softDelete").(bool) ) {
+		call := config.clientBigQuery.Tables.Delete(config.Project, d.Get("datasetId").(string), d.Get("tableId").(string))
+		err := call.Do()
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId("")

--- a/resource_bigquery_table_test.go
+++ b/resource_bigquery_table_test.go
@@ -19,7 +19,7 @@ func TestAccBigqueryTableCreate(t *testing.T) {
 				Config: testAccBigQueryTable,
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigQueryTableExists(
-						"google_bigquery_table.foobar"),
+						"googlebigquery_table.foobar"),
 				),
 			},
 		},
@@ -37,7 +37,7 @@ func TestAccBigqueryTableCreateFieldsFile(t *testing.T) {
 				Config: testAccBigQueryTableJsonFile,
 				Check: resource.ComposeTestCheckFunc(
 					testAccBigQueryTableExists(
-						"google_bigquery_table.foobar"),
+						"googlebigquery_table.foobar"),
 				),
 			},
 		},
@@ -46,14 +46,14 @@ func TestAccBigqueryTableCreateFieldsFile(t *testing.T) {
 
 func testAccCheckBigQueryTableDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_bigquery_table" {
+		if rs.Type != "googlebigquery_table" {
 			continue
 		}
 
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientBigQuery.Tables.Get(config.Project, rs.Primary.Attributes["datasetId"], rs.Primary.Attributes["name"]).Do()
-		if err != nil {
-			fmt.Errorf("Table still present")
+		if err == nil {
+			return fmt.Errorf("Table still present")
 		}
 	}
 
@@ -73,7 +73,7 @@ func testAccBigQueryTableExists(n string) resource.TestCheckFunc {
 		config := testAccProvider.Meta().(*Config)
 		_, err := config.clientBigQuery.Tables.Get(config.Project, rs.Primary.Attributes["datasetId"], rs.Primary.Attributes["name"]).Do()
 		if err != nil {
-			fmt.Errorf("BigQuery Table not present")
+			return fmt.Errorf("BigQuery Table not present")
 		}
 
 		return nil
@@ -81,13 +81,13 @@ func testAccBigQueryTableExists(n string) resource.TestCheckFunc {
 }
 
 const testAccBigQueryTable = `
-resource "google_bigquery_dataset" "foobar" {
+resource "googlebigquery_dataset" "foobar" {
 	datasetId = "foobar"
 }
 
-resource "google_bigquery_table" "foobar" {
+resource "googlebigquery_table" "foobar" {
 	tableId = "foobar"
-	datasetId = "${google_bigquery_dataset.foobar.datasetId}"
+	datasetId = "${googlebigquery_dataset.foobar.datasetId}"
 	
 	schema {
 		description = "field"
@@ -103,13 +103,13 @@ resource "google_bigquery_table" "foobar" {
 }`
 
 const testAccBigQueryTableJsonFile = `
-resource "google_bigquery_dataset" "foobar" {
+resource "googlebigquery_dataset" "foobar" {
 	datasetId = "foobar"
 }
 
-resource "google_bigquery_table" "foobar" {
+resource "googlebigquery_table" "foobar" {
 	tableId = "foobar"
-	datasetId = "${google_bigquery_dataset.foobar.datasetId}"
+	datasetId = "${googlebigquery_dataset.foobar.datasetId}"
 
 	schemaFile = "./test-fixtures/fake_bigquery_table.json"
 }`


### PR DESCRIPTION
this flag allows the user to delete the resource from the tf
statefile but leave the resource in bq.

this is non-standard and probably won't be allowed back upstream
but *shrug* its important